### PR TITLE
Update SteamUGCHandle.java

### DIFF
--- a/java-wrapper/src/main/java/com/codedisaster/steamworks/SteamUGCHandle.java
+++ b/java-wrapper/src/main/java/com/codedisaster/steamworks/SteamUGCHandle.java
@@ -1,7 +1,7 @@
 package com.codedisaster.steamworks;
 
 public class SteamUGCHandle {
-	long handle;
+	public long handle;
 
 	SteamUGCHandle(long handle) {
 		this.handle = handle;


### PR DESCRIPTION
Currently there was no way to access the long handle value at all after the SteamUGCHandle had been created.

Also the Example seems to be layed out for a public handle access.
