### PR TITLE
Update SteamPublishedFileID.java

### DIFF
--- a/java-wrapper/src/main/java/com/codedisaster/steamworks/SteamPublishedFileID.java
+++ b/java-wrapper/src/main/java/com/codedisaster/steamworks/SteamPublishedFileID.java
@@ -1,7 +1,7 @@
 package com.codedisaster.steamworks;
 
 public class SteamPublishedFileID {
-	final long id;
+	public final long id;
 
 	SteamPublishedFileID(long id) {
 		this.id = id;


### PR DESCRIPTION
The published file id is needed to follow the best practices for publishing a file on the Steam Workshop

("After a user submits an item, open a browser window them to the Steam Workshop page for that item.")
