### PR TITLE
Update SteamUtils.java

### DIFF
--- a/java-wrapper/src/main/java/com/codedisaster/steamworks/SteamUtils.java
+++ b/java-wrapper/src/main/java/com/codedisaster/steamworks/SteamUtils.java
@@ -2,7 +2,7 @@ package com.codedisaster.steamworks;
 
 public class SteamUtils extends SteamInterface {
 
-	enum NotificationPosition {
+	public enum NotificationPosition {
 		TopLeft,
 		TopRight,
 		BottomLeft,


### PR DESCRIPTION
Needs to be visible for the enums to be accessible while calling setOverlayNotificationPosition.