### PR TITLE
Add a way to get the actual workshop item id

### DIFF
--- a/java-wrapper/src/main/java/com/codedisaster/steamworks/SteamPublishedFileID.java
+++ b/java-wrapper/src/main/java/com/codedisaster/steamworks/SteamPublishedFileID.java
@@ -5,4 +5,9 @@ public class SteamPublishedFileID extends SteamNativeHandle {
 	public SteamPublishedFileID(long id) {
 		super(id);
 	}
+	
+	public long getWorkshopItemId(){
+		return this.handle;	
+	}
+	
 }


### PR DESCRIPTION
For my game I need a way to actually get what the published file id is to send over the network.