### PR TITLE
Set Java bytecode compatibility version explicitly

### DIFF
--- a/java-wrapper/pom.xml
+++ b/java-wrapper/pom.xml
@@ -140,10 +140,11 @@
 		<plugins>
 			<plugin>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.0</version>
+				<version>3.6.0</version>
 				<configuration>
 					<source>1.8</source>
 					<target>1.8</target>
+					<release>8</release>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
Fix building repo with modern Java causes incompatible bytecode. See https://www.morling.dev/blog/bytebuffer-and-the-dreaded-nosuchmethoderror/ on why that is and why the source and target flags are insufficient. Had to also bump the maven-compile-plugin version to support the release flag.

In my case the call to [ByteBuffer.limit](https://github.com/code-disaster/steamworks4j/blob/ef67e279f6a71f4236be39f91d1978c03518ea04/java-wrapper/src/main/java/com/codedisaster/steamworks/SteamUser.java#L47) caused a MethodNotFound exception when
1. Compiled with Java 17
2. Executed on Java 1.8