### PR TITLE
DRAFT: Update linux build scripts for arm64

### DIFF
--- a/build-natives/build-linux-arm64.sh
+++ b/build-natives/build-linux-arm64.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+premake5 --file=build-linux.lua gmake
+make clean config=release_arm64
+make config=release_arm64
+mv bin/arm64/release/libsteamworks4j.so ../java-wrapper/src/main/resources/libsteamworks4j.so
+mv bin/arm64/release/libsteamworks4j-server.so ../server/src/main/resources/libsteamworks4j-server.so
+mv bin/arm64/release/libsteamworks4j-encryptedappticket.so ../server/src/main/resources/libsteamworks4j-encryptedappticket.so

--- a/build-natives/build-linux-x86_64.sh
+++ b/build-natives/build-linux-x86_64.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+premake5 --file=build-linux.lua gmake
+make clean config=release_x64
+make config=release_x64
+mv bin/x64/release/libsteamworks4j.so ../java-wrapper/src/main/resources/libsteamworks4j.so
+mv bin/x64/release/libsteamworks4j-server.so ../server/src/main/resources/libsteamworks4j-server.so
+mv bin/x64/release/libsteamworks4j-encryptedappticket.so ../server/src/main/resources/libsteamworks4j-encryptedappticket.so

--- a/build-natives/build-linux.lua
+++ b/build-natives/build-linux.lua
@@ -1,6 +1,6 @@
 solution "steamworks4j"
 	configurations { "release" }
-	platforms { "x64" }
+	platforms { "x64", "arm64" }
 
 	buildoptions {
 		"-std=c++11",
@@ -18,9 +18,18 @@ solution "steamworks4j"
 		"LINUX"
 	}
 
-	flags {
-		"Optimize"
+	steam_arch = {
+		x86_64 = "linux64",
+		ARM64  = "linuxarm64"
 	}
+
+	filter "platforms:x64"
+		architecture "x86_64"
+	filter "platforms:arm64"
+		architecture "ARM64"
+	filter {}
+
+	libdirs { "../sdk/redistributable_bin/%{steam_arch[cfg.architecture]}" }
 
 	project "steamworks4j"
 
@@ -35,12 +44,9 @@ solution "steamworks4j"
 			"../java-wrapper/src/main/native",
 		}
 
-        libdirs {
-            "../sdk/redistributable_bin/linux64"
-        }
-        links {
-            "steam_api"
-        }
+        	links {
+        	    "steam_api"
+        	}
 
 	project "steamworks4j-server"
 
@@ -59,12 +65,9 @@ solution "steamworks4j"
 			"../server/src/main/native",
 		}
 
-        libdirs {
-            "../sdk/redistributable_bin/linux64"
-        }
-        links {
-            "steam_api"
-        }
+        	links {
+        	    "steam_api"
+        	}
 
 	project "steamworks4j-encryptedappticket"
 
@@ -79,9 +82,8 @@ solution "steamworks4j"
 			"../server/src/main/native",
 		}
 
-        libdirs {
-            "../sdk/public/steam/lib/linux64"
-        }
-        links {
-            "sdkencryptedappticket"
-        }
+	        libdirs { "../sdk/public/steam/lib/%{steam_arch[cfg.architecture]}" }
+
+        	links {
+        	    "sdkencryptedappticket"
+        	}


### PR DESCRIPTION
`
Since Steamworks SDK 1.63 introduced the arm64 architecture (linuxarm64), it’s now possible to work with the Steam API on arm64 (aarch64) hosts. It’s not possible to create fat libraries on Linux like on macOS, so the arm64 build script is separate from the x86_64 variant.
`

It is not entirely clear to me how game developers will distribute arm64 versions of their games, but in the future, a more universal approach like the one on macOS will probably be necessary. Marked as a draft, but the build and linking are works.

UPD: this also updates dependency from premake4 to premake5